### PR TITLE
Adding hover state for Instagram and LinkedIn socials

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -803,6 +803,19 @@ ul.top-links li {
     background: #dd4b39;
     transition: 0.5s ease-in;
 }
+.social-icons i.fa.fa-instagram:hover {
+    color: #f2f3f5;
+    border: 2px solid #f2f3f5;
+    background: #C13584;
+    transition: 0.5s ease-in;
+}
+.social-icons i.fa.fa-linkedin:hover {
+    color: #f2f3f5;
+    border: 2px solid #f3f4f7;
+    background: #04669A;
+    transition: 0.5s ease-in;
+}
+
 /*-- //footer --*/
 
 /*  newsletter */


### PR DESCRIPTION
I have successfully added the hover state for Instagram and LinkedIn buttons which earlier did not change their state on hover unlike the other socials (Facebook, Twitter and Google plus). 
Issue solved #129 

The screenshots of the changes made:
![Instagram_hover_state](https://github.com/Anupkjha2601/food-recipes-website/assets/112184998/a3e6b045-941d-46aa-88f5-d8c6d98ad7e1)
![LinkedIn_hover_state](https://github.com/Anupkjha2601/food-recipes-website/assets/112184998/9c55f653-1562-40f1-be86-ec98d1ef3a92)
