### PR TITLE
docs: make gssoc banner adaptive to github dark/light mode 💫✨ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Once approved, it will be merged into the main repository.
 <div align="center">
 	<h1>This project is a part of Open Source Program ✨</h1>
 	<br>
-	<a href="https://gssoc.girlscript.tech/">
-		<img src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png">
-	</a>
+	  <picture>
+	    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png">
+	    <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png">
+	    <img alt="Girlscript Summer of Code" width=80% src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png">
+	  </picture>
 </div>
      
 


### PR DESCRIPTION
## Close #693 

## Description
- Made GSSOC Banner adaptive to Github's Dark/Light Mode with using `picture` element with media queries.
- This PR will improve the overall readability of Food Recipes Website Repository's Documentation.

## Screenshot

| LIGHT MODE|DARK MODE |
|:----:|:----:|
|![image](https://github.com/Anupkjha2601/food-recipes-website/assets/92252895/590cfc18-b194-4940-8684-75d803fac85e)| ![image](https://github.com/Anupkjha2601/food-recipes-website/assets/92252895/04aff50d-0b2e-4650-8d64-504155b17064)|