### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.vscode/


### PR DESCRIPTION
Fixes #851 

## Changes proposed
Added '.gitignore' file


Adding a '.gitgnore' file to a project is really important as files and folders like '.vscode' and '.DS_Store' contains config files for your local device. Committing these files to a repository may lead to bugs when cloned on a different machine. For example, if your project uses port 5501 on your computer, it is not necessary that the same port will be available on a different computer.

Therefore, adding a '.gitignore' file helps to not commit unwanted files and folders to a repository.
